### PR TITLE
No numeric fluents in domain; LAMA planner interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 2. [Dependencies](#dependencies)
 3. [Design principles](#design-principles)
 4. [Usage examples](#usage-examples)
-5. [API description](#api-description)
+    1. [Knowledge base](#knowledge-base)
+    2. [Task planner](#task-planner)
+5. [Planner setup](#planner-setup)
+6. [Tests](#tests)
+7. [API description](#api-description)
     1. [Planner API](#planner-api)
     2. [Knowledge base API](#knowledge-base-api)
         1. [KnowledgeBaseInterface](#knowledgebaseinterface)
@@ -134,6 +138,12 @@ task_goals = [('load_at', [('load', task_request.load_id),
 # requesting a plan
 plan_found, plan = planner.plan(task_request, robot_name, task_goals)
 ```
+
+## Planner Setup
+
+For setting up the LAMA planner, the instructions at https://github.com/b-it-bots/lama_planner should suffice.
+
+For Metric-FF, the executable can be downloaded from the home page of the planner: https://fai.cs.uni-saarland.de/hoffmann/metric-ff.html
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Note: The package is developed for Python 3.5+ since it makes use of Python typi
 ## Dependencies
 
 * `pymongo`
-* `termcolor`
+* `numpy`
+* `PyYAML`
 * [`ropod_common`](https://github.com/ropod-project/ropod_common)
 
 ## Design principles and assumptions

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ from task_planner.knowledge_base_interface import KnowledgeBaseInterface
 kb_interface = KnowledgeBaseInterface('ropod_kb')
 ```
 
-Let's say we want to add and remove certain facts (for instance, we want to state that the robot "frank" is at the location "BRSU_L0_C1" and that the load "mobidik_123" is not at "BRSU_L0_C1" anymore); we can specify these facts as follows:
+Let's say we want to add and remove certain facts (e.g. we want to say that the gripper of a robot "frank" is empty and that it is not holding the load "mobidik_123" anymore); we can specify these facts as follows:
 
 ```
-facts_to_add = [('robot_at', [('bot', 'frank'), ('loc', 'BRSU_L0_C1')])]
-facts_to_remove = [('load_at', [('load', 'mobidik_123'), ('loc', 'BRSU_L0_C1')])]
+facts_to_add = [('empty_gripper', [('bot', 'frank')])]
+facts_to_remove = [('holding', [('bot', 'frank'), ('load', 'mobidik_123')])]
 ```
 
 Note that we represent a predicate as a tuple in which the first entry is the predicate name and the second is a list of predicate parameters ("name" and "value" pairs).
@@ -78,28 +78,33 @@ or with one function call:
 kb_interface.update_kb(facts_to_add, facts_to_remove)
 ```
 
-If the facts are fluents instead of predicate assertions (e.g. we want to insert or remove the fact that the robot "frank" is on the second floor), we can insert/remove them as follows:
+If the facts are fluents instead of predicate assertions (e.g. we want to state that the robot "frank" is at the location "BRSU_L0_C1" and that the load "mobidik_123" is not at "BRSU_L0_C1" anymore, and we also want to insert the fact that the robot "frank" is on the second floor, while the load "mobidik_123" is not on the ground floor), we can insert/remove them as follows:
 
 ```
-fluents = [('robot_floor', [('bot', 'frank')], 2)]
+fluents_to_add = [('robot_at', [('bot', 'frank'), ('loc', 'BRSU_L0_C1')]),
+                  ('robot_floor', [('bot', 'frank')], floor2)]
+fluents_to_remove = [('load_at', [('load', 'mobidik_123'), ('loc', 'BRSU_L0_C1')]),
+                     ('load_floor', [('bot', 'frank')], floor0)]
 
 # adding the fluents to the knowledge base
-kb_interface.insert_fluents(fluents)
+kb_interface.insert_fluents(fluents_to_add)
 
 # or removing them from it
-kb_interface.remove_fluents(fluents)
+kb_interface.remove_fluents(fluents_to_remove)
 ```
 
 Note that a fluent is also represented as a tuple, but with three entries instead of two, such that the first entry is the fluent name, the second a list of predicate parameters ("name" and "value" pairs), and the third the fluent value.
 
 Planning goals can be inserted/removed just as facts, only that the function calls change (`insert_goals` and `remove_goals` respectively). Note that only predicates can be inserted as planning goals.
 
+For a list of defined predicates and fluents, please consult the [knowledge_models](task_planner/knowledge_models.py) collection of domain mappings.
+
 ### Task planner
 
-An example of using the MetricFF task planner to create a plan for a Mobidik transportation task is given below:
+An example of using the LAMA task planner to create a plan for a Mobidik transportation task is given below:
 
 ```
-from task_planner.lama_interface import LAMAFFInterface
+from task_planner.lama_interface import LAMAInterface
 
 # reading the planner configuration parameters
 domain_file = ''

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 Defines a package (`task_planner`) that exposes interfaces to a knowledge base and a task planner.
 
-Only the [Metric-FF](https://fai.cs.uni-saarland.de/hoffmann/metric-ff.html) planner is currently supported.
+Both [LAMA](https://arxiv.org/abs/1401.3839) and [Metric-FF](https://arxiv.org/abs/1106.5271) are currently supported.
 
 Parameters for the planner are specified in `config/planner_config.yaml`; in particular, the following parameters need to be specified:
 * `planner_name`: Name of the used planner
@@ -99,7 +99,7 @@ Planning goals can be inserted/removed just as facts, only that the function cal
 An example of using the MetricFF task planner to create a plan for a Mobidik transportation task is given below:
 
 ```
-from task_planner.metric_ff_interface import MetricFFInterface
+from task_planner.lama_interface import LAMAFFInterface
 
 # reading the planner configuration parameters
 domain_file = ''
@@ -111,7 +111,7 @@ with open('config/planner_config.yaml', 'r') as config_file:
     planner_cmd = planner_config['planner_cmd']
     plan_file_path = planner_config['plan_file_path']
 
-planner = MetricFFInterface('ropod_kb', domain_file, planner_cmd, plan_file_path, debug=True)
+planner = LAMAInterface('ropod_kb', domain_file, planner_cmd, plan_file_path, debug=True)
 
 # creating a task request
 task_request = TaskRequest()
@@ -129,11 +129,17 @@ task_goals = [('load_at', [('load', task_request.load_id),
 plan_found, plan = planner.plan(task_request, robot_name, task_goals)
 ```
 
+## Tests
+
+Unit tests are included under [test](test) (currently only for the LAMA planner).
+
 ## API description
 
 ### Planner API
 
-The task planner exposes functionalities for creating a task plan given a task request and a robot task assignment. The package includes a generic interface definition - the abstract `TaskPlannerInterface` class in [`task_planner/planner_interface.py`](task_planner/planner_interface.py) - as well as a specific implementation that uses the Metric-FF planner - the `MetricFFInterface` class in [`task_planner/metric_ff_interface.py`](task_planner/metric_ff_interface.py).
+The task planner exposes functionalities for creating a task plan given a task request and a robot task assignment. The package includes a generic interface definition - the abstract `TaskPlannerInterface` class in [`task_planner/planner_interface.py`](task_planner/planner_interface.py) - as well as planner-specific implementations, namely:
+* the `LAMAInterface` class in [`task_planner/lama_interface.py`](task_planner/lama_interface.py)
+* the `MetricFFInterface` class in [`task_planner/metric_ff_interface.py`](task_planner/metric_ff_interface.py)
 
 #### TaskPlannerInterface
 
@@ -141,7 +147,7 @@ An abstract class containing the following fields:
 * `kb_database_name`: Name of a database for storing the knowledge base
 * `domain_file`: Absolute path of a planning domain file
 * `domain_name`: Name of the planning domain (extracted from the domain file)
-* `planner_cmd`: Command used for running a task planner; the words "DOMAIN" and "PROBLEM" are expected to be in the command so that they can be appropriately replaced with the paths of domain and problem files
+* `planner_cmd`: Command used for running a task planner; the words "DOMAIN" and "PROBLEM" are expected to be in the command so that they can be appropriately replaced with the paths of domain and problem files; for LAMA, the word "PLAN-FILE" is also expected to be passed since the planner potentially generates multiple plan files
 * `plan_file_path`: Directory where generated plan files should be saved
 * `debug`: A Boolean indicating whether to run the planner in debug mode (thus providing more detailed debugging output)
 

--- a/config/planner_config.yaml
+++ b/config/planner_config.yaml
@@ -1,4 +1,4 @@
-planner_name: Metric-FF
-domain_file: [path-to-config]/config/task_domains/agaplesion/hospital_transportation.pddl
-planner_cmd: [path-to-executable]bin/Metric-FF -o DOMAIN -f PROBLEM -s 0
+planner_name: LAMA
+domain_file: /path/to/config/task_domains/agaplesion/hospital_transportation.pddl
+planner_cmd: /path/to/fast-downward/fast-downward.py --plan-file PLAN-FILE --search-time-limit 10 --alias seq-sat-lama-2011 DOMAIN PROBLEM
 plan_file_path: .

--- a/config/sample_problems/sample_mobidik_problem_robot_cart_diff_floors.pddl
+++ b/config/sample_problems/sample_mobidik_problem_robot_cart_diff_floors.pddl
@@ -6,20 +6,21 @@
         charging_station somewhere_on_floor1 pickup_location delivery_location elevator0 elevator1 elevator2 - location
         mobidik - load
         toma_elevator - elevator
+        floor0 floor1 floor2 unknown - floor
     )
 
     (:init
-        (= (robot_floor frank) 1)
-        (= (load_floor mobidik) 0)
-        (= (location_floor charging_station) 0)
-        (= (location_floor pickup_location) 0)
-        (= (location_floor somewhere_on_floor1) 1)
-        (= (location_floor elevator0) 0)
-        (= (location_floor elevator1) 1)
-        (= (location_floor elevator2) 2)
-        (= (location_floor delivery_location) 2)
-        (= (elevator_floor toma_elevator) 100)
-        (= (destination_floor toma_elevator) 100)
+        (robot_floor frank floor1)
+        (load_floor mobidik floor0)
+        (location_floor charging_station floor0)
+        (location_floor pickup_location floor0)
+        (location_floor somewhere_on_floor1 floor1)
+        (location_floor elevator0 floor0)
+        (location_floor elevator1 floor1)
+        (location_floor elevator2 floor2)
+        (location_floor delivery_location floor2)
+        (elevator_floor toma_elevator unknown)
+        (destination_floor toma_elevator unknown)
 
         (robot_at frank somewhere_on_floor1)
         (load_at mobidik pickup_location)

--- a/config/sample_problems/sample_mobidik_problem_robot_cart_same_floor.pddl
+++ b/config/sample_problems/sample_mobidik_problem_robot_cart_same_floor.pddl
@@ -6,18 +6,19 @@
         charging_station pickup_location delivery_location elevator0 elevator2 - location
         mobidik - load
         toma_elevator - elevator
+        floor0 floor2 unknown - floor
     )
 
     (:init
-        (= (robot_floor frank) 0)
-        (= (load_floor mobidik) 0)
-        (= (location_floor charging_station) 0)
-        (= (location_floor pickup_location) 0)
-        (= (location_floor elevator0) 0)
-        (= (location_floor elevator2) 2)
-        (= (location_floor delivery_location) 2)
-        (= (elevator_floor toma_elevator) 100)
-        (= (destination_floor toma_elevator) 100)
+        (robot_floor frank floor0)
+        (load_floor mobidik floor0)
+        (location_floor charging_station floor0)
+        (location_floor pickup_location floor0)
+        (location_floor elevator0 floor0)
+        (location_floor elevator2 floor2)
+        (location_floor delivery_location floor0)
+        (elevator_floor toma_elevator unknown)
+        (destination_floor toma_elevator unknown)
 
         (robot_at frank charging_station)
         (load_at mobidik pickup_location)

--- a/config/task_domains/agaplesion/hospital_transportation.pddl
+++ b/config/task_domains/agaplesion/hospital_transportation.pddl
@@ -82,12 +82,13 @@
     )
 
     (:action REQUEST_ELEVATOR
-        :parameters (?bot - robot ?from ?to - location ?elevator - elevator ?loc_floor ?floor_from ?floor_to - floor)
+        :parameters (?bot - robot ?from ?to - location ?elevator - elevator ?loc_floor ?floor_from ?floor_to ?believed_floor_to - floor)
         :precondition (and
             (robot_at ?bot ?from)
             (elevator_at ?elevator ?from)
             (location_floor ?from ?floor_from)
             (location_floor ?to ?floor_to)
+            (destination_floor ?elevator ?believed_floor_to)
             (not (= ?floor_from ?floor_to))
             (forall (?elevator - elevator)
                 (and
@@ -97,6 +98,7 @@
             )
         )
         :effect (and
+            (not (destination_floor ?elevator ?believed_floor_to))
             (requested ?bot ?elevator)
             (destination_floor ?elevator ?floor_to)
         )
@@ -114,19 +116,17 @@
     )
 
     (:action ENTER_ELEVATOR
-        :parameters (?bot - robot ?loc - location ?dest_loc - location ?dest_floor - floor ?elevator - elevator ?load - load)
+        :parameters (?bot - robot ?loc - location ?elevator - elevator ?load - load)
         :precondition (and
             (robot_at ?bot ?loc)
             (elevator_at ?elevator ?loc)
             (requested ?bot ?elevator)
             (arrived ?elevator)
-            (location_floor ?dest_loc ?dest_floor)
         )
         :effect (and
             (robot_in ?bot ?elevator)
             (not (robot_at ?bot ?loc))
             (not (arrived ?elevator))
-            (destination_floor ?elevator ?dest_floor)
             (when (and (holding ?bot ?load))
                 (and (load_in ?load ?elevator))
             )
@@ -142,30 +142,35 @@
         :effect (and
             (elevator_floor ?elevator ?dest_floor)
             (robot_floor ?bot ?dest_floor)
+            (when (and (holding ?bot ?load))
+                (and
+                    (load_floor ?load ?dest_floor)
+                )
+            )
         )
     )
 
     (:action EXIT_ELEVATOR
-        :parameters (?bot - robot ?loc - location ?elevator - elevator ?load - load ?elev_floor ?dest_floor - floor)
+        :parameters (?bot - robot ?loc - location ?elevator - elevator ?load - load ?robot_floor ?dest_floor - floor)
         :precondition (and
             (robot_in ?bot ?elevator)
             (elevator_at ?elevator ?loc)
             (arrived ?elevator)
-            (elevator_floor ?elevator ?elev_floor)
+            (robot_floor ?bot ?robot_floor)
             (destination_floor ?elevator ?dest_floor)
-            (= ?elev_floor ?dest_floor)
+            (location_floor ?loc ?dest_floor)
+            (= ?robot_floor ?dest_floor)
         )
         :effect (and
             (robot_at ?bot ?loc)
             (not (robot_in ?bot ?elevator))
             (not (arrived ?elevator))
             (not (requested ?bot ?elevator))
-            (robot_floor ?bot ?elev_floor)
+            (not (elevator_floor ?elevator ?dest_floor))
             (when (and (holding ?bot ?load))
                 (and
                     (not (load_in ?load ?elevator))
                     (load_at ?load ?loc)
-                    (load_floor ?load ?elev_floor)
                 )
             )
         )

--- a/config/task_domains/agaplesion/hospital_transportation.pddl
+++ b/config/task_domains/agaplesion/hospital_transportation.pddl
@@ -55,7 +55,7 @@
     )
 
     (:action DOCK
-        :parameters (?bot - robot ?load - load ?bot_floor ?loc_floor - floor ?loc - location)
+        :parameters (?bot - robot ?load - load ?loc - location ?bot_floor ?loc_floor - floor)
         :precondition (and
             (robot_at ?bot ?loc)
             (load_at ?load ?loc)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pymongo
+numpy
+PyYAML
+git+https://github.com/ropod-project/ropod_common.git#egg=ropod_common

--- a/task_planner/knowledge_models.py
+++ b/task_planner/knowledge_models.py
@@ -30,31 +30,6 @@ class PDDLPredicateLibrary(object):
         return ordered_param_list, updated_obj_types
 
     @staticmethod
-    def robot_at(params: list, obj_types: dict) -> Tuple[list, dict]:
-        param_order = {0: ('bot', 'robot'), 1: ('loc', 'location')}
-        return PDDLKnowledgeUtils.get_ordered_param_list(params, param_order, obj_types)
-
-    @staticmethod
-    def robot_in(params: list, obj_types: dict) -> Tuple[list, dict]:
-        param_order = {0: ('bot', 'robot'), 1: ('elevator', 'elevator')}
-        return PDDLKnowledgeUtils.get_ordered_param_list(params, param_order, obj_types)
-
-    @staticmethod
-    def load_at(params: list, obj_types: dict) -> Tuple[list, dict]:
-        param_order = {0: ('load', 'load'), 1: ('loc', 'location')}
-        return PDDLKnowledgeUtils.get_ordered_param_list(params, param_order, obj_types)
-
-    @staticmethod
-    def load_in(params: list, obj_types: dict) -> Tuple[list, dict]:
-        param_order = {0: ('load', 'load'), 1: ('elevator', 'elevator')}
-        return PDDLKnowledgeUtils.get_ordered_param_list(params, param_order, obj_types)
-
-    @staticmethod
-    def elevator_at(params: list, obj_types: dict) -> Tuple[list, dict]:
-        param_order = {0: ('elevator', 'elevator'), 1: ('loc', 'location')}
-        return PDDLKnowledgeUtils.get_ordered_param_list(params, param_order, obj_types)
-
-    @staticmethod
     def empty_gripper(params: list, obj_types: dict) -> Tuple[list, dict]:
         param_order = {0: ('bot', 'robot')}
         return PDDLKnowledgeUtils.get_ordered_param_list(params, param_order, obj_types)
@@ -74,6 +49,137 @@ class PDDLPredicateLibrary(object):
         param_order = {0: ('elevator', 'elevator')}
         return PDDLKnowledgeUtils.get_ordered_param_list(params, param_order, obj_types)
 
+    @staticmethod
+    def elevator_at(params: list, obj_types: dict) -> Tuple[list, dict]:
+        param_order = {0: ('elevator', 'elevator'), 1: ('loc', 'location')}
+        return PDDLKnowledgeUtils.get_ordered_param_list(params, param_order, obj_types)
+
+class PDDLFluentLibrary(object):
+    @staticmethod
+    def get_assertion_param_list(fluent_name: str, fluent_params: list,
+                                 fluent_value: str, obj_types: dict) -> Tuple[list, dict]:
+        ordered_param_list, obj_types = getattr(PDDLFluentLibrary, fluent_name)(fluent_params,
+                                                                                obj_types,
+                                                                                fluent_value)
+        return ordered_param_list, obj_types
+
+    @staticmethod
+    def robot_at(params: list, obj_types: dict, fluent_value: str) -> Tuple[list, dict]:
+        param_order = {0: ('bot', 'robot')}
+        ordered_param_list, updated_obj_types = PDDLKnowledgeUtils.get_ordered_param_list(params,
+                                                                                          param_order,
+                                                                                          obj_types)
+        if 'location' in updated_obj_types:
+            if fluent_value not in updated_obj_types['location']:
+                updated_obj_types['location'].append(fluent_value)
+        else:
+            updated_obj_types['location'] = [fluent_value]
+        return ordered_param_list, updated_obj_types
+
+    @staticmethod
+    def robot_in(params: list, obj_types: dict, fluent_value: str) -> Tuple[list, dict]:
+        param_order = {0: ('bot', 'robot')}
+        ordered_param_list, updated_obj_types = PDDLKnowledgeUtils.get_ordered_param_list(params,
+                                                                                          param_order,
+                                                                                          obj_types)
+        if 'elevator' in updated_obj_types:
+            if fluent_value not in updated_obj_types['elevator']:
+                updated_obj_types['elevator'].append(fluent_value)
+        else:
+            updated_obj_types['elevator'] = [fluent_value]
+        return ordered_param_list, updated_obj_types
+
+    @staticmethod
+    def load_at(params: list, obj_types: dict, fluent_value: str) -> Tuple[list, dict]:
+        param_order = {0: ('load', 'load')}
+        ordered_param_list, updated_obj_types = PDDLKnowledgeUtils.get_ordered_param_list(params,
+                                                                                          param_order,
+                                                                                          obj_types)
+        if 'location' in updated_obj_types:
+            if fluent_value not in updated_obj_types['location']:
+                updated_obj_types['location'].append(fluent_value)
+        else:
+            updated_obj_types['location'] = [fluent_value]
+        return ordered_param_list, updated_obj_types
+
+    @staticmethod
+    def load_in(params: list, obj_types: dict, fluent_value: str) -> Tuple[list, dict]:
+        param_order = {0: ('load', 'load')}
+        ordered_param_list, updated_obj_types = PDDLKnowledgeUtils.get_ordered_param_list(params,
+                                                                                          param_order,
+                                                                                          obj_types)
+        if 'elevator' in updated_obj_types:
+            if fluent_value not in updated_obj_types['elevator']:
+                updated_obj_types['elevator'].append(fluent_value)
+        else:
+            updated_obj_types['elevator'] = [fluent_value]
+        return ordered_param_list, updated_obj_types
+
+    @staticmethod
+    def robot_floor(params: list, obj_types: dict, fluent_value: str) -> Tuple[list, dict]:
+        param_order = {0: ('bot', 'robot')}
+        ordered_param_list, updated_obj_types = PDDLKnowledgeUtils.get_ordered_param_list(params,
+                                                                                          param_order,
+                                                                                          obj_types)
+        if 'floor' in updated_obj_types:
+            if fluent_value not in updated_obj_types['floor']:
+                updated_obj_types['floor'].append(fluent_value)
+        else:
+            updated_obj_types['floor'] = [fluent_value]
+        return ordered_param_list, updated_obj_types
+
+    @staticmethod
+    def load_floor(params: list, obj_types: dict, fluent_value: str) -> Tuple[list, dict]:
+        param_order = {0: ('load', 'load')}
+        ordered_param_list, updated_obj_types = PDDLKnowledgeUtils.get_ordered_param_list(params,
+                                                                                          param_order,
+                                                                                          obj_types)
+        if 'floor' in updated_obj_types:
+            if fluent_value not in updated_obj_types['floor']:
+                updated_obj_types['floor'].append(fluent_value)
+        else:
+            updated_obj_types['floor'] = [fluent_value]
+        return ordered_param_list, updated_obj_types
+
+    @staticmethod
+    def location_floor(params: list, obj_types: dict, fluent_value: str) -> Tuple[list, dict]:
+        param_order = {0: ('loc', 'location')}
+        ordered_param_list, updated_obj_types = PDDLKnowledgeUtils.get_ordered_param_list(params,
+                                                                                          param_order,
+                                                                                          obj_types)
+        if 'floor' in updated_obj_types:
+            if fluent_value not in updated_obj_types['floor']:
+                updated_obj_types['floor'].append(fluent_value)
+        else:
+            updated_obj_types['floor'] = [fluent_value]
+        return ordered_param_list, updated_obj_types
+
+    @staticmethod
+    def elevator_floor(params: list, obj_types: dict, fluent_value: str) -> Tuple[list, dict]:
+        param_order = {0: ('elevator', 'elevator')}
+        ordered_param_list, updated_obj_types = PDDLKnowledgeUtils.get_ordered_param_list(params,
+                                                                                          param_order,
+                                                                                          obj_types)
+        if 'floor' in updated_obj_types:
+            if fluent_value not in updated_obj_types['floor']:
+                updated_obj_types['floor'].append(fluent_value)
+        else:
+            updated_obj_types['floor'] = [fluent_value]
+        return ordered_param_list, updated_obj_types
+
+    @staticmethod
+    def destination_floor(params: list, obj_types: dict, fluent_value: str) -> Tuple[list, dict]:
+        param_order = {0: ('elevator', 'elevator')}
+        ordered_param_list, updated_obj_types = PDDLKnowledgeUtils.get_ordered_param_list(params,
+                                                                                          param_order,
+                                                                                          obj_types)
+        if 'floor' in updated_obj_types:
+            if fluent_value not in updated_obj_types['floor']:
+                updated_obj_types['floor'].append(fluent_value)
+        else:
+            updated_obj_types['floor'] = [fluent_value]
+        return ordered_param_list, updated_obj_types
+
 
 class PDDLNumericFluentLibrary(object):
     @staticmethod
@@ -84,11 +190,6 @@ class PDDLNumericFluentLibrary(object):
     @staticmethod
     def robot_floor(params: list, obj_types: dict) -> Tuple[list, dict]:
         param_order = {0: ('bot', 'robot')}
-        return PDDLKnowledgeUtils.get_ordered_param_list(params, param_order, obj_types)
-
-    @staticmethod
-    def location_floor(params: list, obj_types: dict) -> Tuple[list, dict]:
-        param_order = {0: ('loc', 'location')}
         return PDDLKnowledgeUtils.get_ordered_param_list(params, param_order, obj_types)
 
     @staticmethod

--- a/task_planner/knowledge_models.py
+++ b/task_planner/knowledge_models.py
@@ -75,10 +75,10 @@ class PDDLPredicateLibrary(object):
         return PDDLKnowledgeUtils.get_ordered_param_list(params, param_order, obj_types)
 
 
-class PDDLFluentLibrary(object):
+class PDDLNumericFluentLibrary(object):
     @staticmethod
     def get_assertion_param_list(fluent_name: str, fluent_params: list, obj_types: dict) -> Tuple[list, dict]:
-        ordered_param_list, obj_types = getattr(PDDLFluentLibrary, fluent_name)(fluent_params, obj_types)
+        ordered_param_list, obj_types = getattr(PDDLNumericFluentLibrary, fluent_name)(fluent_params, obj_types)
         return ordered_param_list, obj_types
 
     @staticmethod

--- a/task_planner/lama_interface.py
+++ b/task_planner/lama_interface.py
@@ -1,0 +1,219 @@
+from os import listdir
+from os.path import join
+from typing import Tuple, Sequence
+import uuid
+import subprocess
+import numpy as np
+import logging
+
+from ropod.structs.task import TaskRequest
+from ropod.structs.action import Action
+from ropod.structs.area import Area
+
+from task_planner.planner_interface import TaskPlannerInterface
+from task_planner.knowledge_base_interface import Predicate
+from task_planner.action_models import ActionModelLibrary
+from task_planner.knowledge_models import PDDLPredicateLibrary, PDDLNumericFluentLibrary
+
+
+class LAMAInterface(TaskPlannerInterface):
+    _plan_file_name = 'plan.txt'
+
+    def __init__(self, kb_database_name, domain_file,
+                 planner_cmd, plan_file_path, debug=False):
+        super(LAMAInterface, self).__init__(kb_database_name, domain_file,
+                                            planner_cmd, plan_file_path,
+                                            debug)
+        self.logger = logging.getLogger('task.planner')
+
+    def plan(self, task_request: TaskRequest, robot: str, task_goals: list=None):
+        '''
+        task_goals can be a list of any of the following variation of Predicate object
+            - Object itself
+            - tuple
+            - dict
+        '''
+        # TODO: check if there are already goals in the knowledge base and,
+        # if yes, add them to the task_goals list
+
+        predicate_task_goals = []
+        for task_goal in task_goals:
+            if isinstance(task_goal, Predicate):
+                predicate_task_goals.append(task_goal)
+            elif isinstance(task_goal, tuple):
+                predicate_task_goals.append(Predicate.from_tuple(task_goal))
+            elif isinstance(task_goal, dict):
+                predicate_task_goals.append(Predicate.from_dict(task_goal))
+            else:
+                raise Exception('Invalid type to task_goal encountered')
+
+        kb_predicate_assertions = self.kb_interface.get_predicate_assertions()
+        kb_fluent_assertions = self.kb_interface.get_fluent_assertions()
+
+        self.logger.info('Generating problem file')
+        problem_file = self.generate_problem_file(kb_predicate_assertions,
+                                                  kb_fluent_assertions,
+                                                  predicate_task_goals)
+
+        planner_cmd = self.planner_cmd.replace('PROBLEM', problem_file)
+        planner_cmd = planner_cmd.replace('PLAN-FILE', self._plan_file_name)
+        planner_cmd_elements = planner_cmd.split()
+
+        self.logger.info('Planning task...')
+        subprocess.run(planner_cmd_elements)
+        self.logger.info('Planning finished')
+
+        plan_found, plan = self.parse_plan(task_request.load_type, robot)
+        return plan_found, plan
+
+    def generate_problem_file(self, predicate_assertions: list,
+                              fluent_assertions: list,
+                              task_goals: Sequence[Predicate]) -> str:
+        obj_types = {}
+        init_state_str = ''
+
+        # we generate strings from the predicate assertions of the form
+        # (predicate_name param_1 param_2 ... param_n)
+        for assertion in predicate_assertions:
+            ordered_param_list, obj_types = PDDLPredicateLibrary.get_assertion_param_list(assertion.name,
+                                                                                          assertion.params,
+                                                                                          obj_types)
+            assertion_str = '        ({0} {1})\n'.format(assertion.name, ' '.join(ordered_param_list))
+            init_state_str += assertion_str
+
+
+        # for numeric fluents, we generate strings of the form
+        # (= (fluent_name param_1 param_2 ... param_n) fluent_value); otherwise,
+        # we generate strings just like for predicate assertions
+        for assertion in fluent_assertions:
+            if hasattr(PDDLPredicateLibrary, assertion.name):
+                ordered_param_list, obj_types = PDDLPredicateLibrary.get_assertion_param_list(assertion.name,
+                                                                                              assertion.params,
+                                                                                              obj_types)
+                assertion_str = '        ({0} {1} {2})\n'.format(assertion.name,
+                                                                 ' '.join(ordered_param_list),
+                                                                 assertion.value)
+            else:
+                ordered_param_list, obj_types = PDDLNumericFluentLibrary.get_assertion_param_list(assertion.name,
+                                                                                                  assertion.params,
+                                                                                                  obj_types)
+                assertion_str = '        (= ({0} {1}) {2})\n'.format(assertion.name,
+                                                                     ' '.join(ordered_param_list),
+                                                                     assertion.value)
+            init_state_str += assertion_str
+
+        # we combine the assertion strings into an initial state string of the form
+        # (:init
+        #     assertions
+        # )
+        init_state_str = '    (:init\n{0}\n    )\n\n'.format(init_state_str)
+
+        # we generate a string with the object types of the form
+        # (:objects
+        #     obj_11 obj_12 - type_1
+        #     ...
+        #     obj_n1 - type_n
+        # )
+        obj_type_str = ''
+        for obj_type in obj_types:
+            obj_type_str += '        {0} - {1}\n'.format(' '.join(obj_types[obj_type]), obj_type)
+        obj_type_str = '    (:objects\n{0}    )\n\n'.format(obj_type_str)
+
+        # we generate a string with the planning goals of the form
+        # (:goals
+        #     (and
+        #         (predicate_1_name param_1 param_2 ... param_n)
+        #         ...
+        #         (predicate_n_name param_1 param_2 ... param_n)
+        #     )
+        # )
+        goal_str = ''
+        for task_goal in task_goals:
+            goal_predicate, goal_params = task_goal.name, task_goal.params
+            goal_str += '            ({0} {1})\n'.format(goal_predicate,
+                                                         ' '.join([param.value for param in goal_params]))
+        goal_str = '    (:goal\n        (and\n{0}        )\n    )\n'.format(goal_str)
+
+        # we finally write the problem file, which will be in the format
+        # (define (problem problem-name)
+        #     (:domain domain-name)
+        #     (:objects
+        #         ...
+        #     )
+        #     (:objects
+        #         ...
+        #     )
+        #     (:goals
+        #         ...
+        #     )
+        # )
+        problem_file_name = 'problem_{0}.pddl'.format(str(uuid.uuid4()))
+        problem_file_abs_path = join(self.plan_file_path, problem_file_name)
+        self.logger.info('Generating planning problem...')
+        with open(problem_file_abs_path, 'w') as problem_file:
+            header = '(define (problem ropod)\n'
+            header += '    (:domain {0})\n'.format(self.domain_name)
+            problem_file.write(header)
+            problem_file.write(obj_type_str)
+            problem_file.write(init_state_str)
+            problem_file.write(goal_str)
+            problem_file.write(')\n')
+        return problem_file_abs_path
+
+    def parse_plan(self, task: str, robot: str) -> Tuple[bool, list]:
+        plan_files = [f for f in listdir(self.plan_file_path)
+                      if f.find(self._plan_file_name) != -1]
+        if not plan_files:
+            self.logger.error('Plan for task %s and robot %s not found', task, robot)
+            return False, []
+
+        plans = []
+        action_strings_per_plan = []
+        for plan_file_name in plan_files:
+            plan = []
+            plan_action_strings = []
+            with open(join(self.plan_file_path, plan_file_name), 'r') as plan_file:
+                while True:
+                    line = plan_file.readline()
+                    if line.find(';') != -1:
+                        break
+                    else:
+                        action_line = line.strip()[1:-1]
+                        action = self.process_action_str(action_line)
+                        for i in range(len(action.areas)):
+                            floor_fluent = ('location_floor', [('loc', action.areas[i].name)])
+                            floor = self.kb_interface.get_fluent_value(floor_fluent)
+
+                            # "floor" is either a string of the form "floorX"
+                            # or the "unknown" string; we thus throw away the word
+                            # "floor" to get the actual floor number - or catch an
+                            # exception and set a default unreasonable floor
+                            # if the floor is not known
+                            try:
+                                floor_number = int(floor[5:])
+                            except ValueError:
+                                floor_number = -100
+                            action.areas[i].floor_number = floor_number
+                        plan.append(action)
+                        plan_action_strings.append(action_line)
+                        self.logger.debug(action_line)
+                plans.append(plan)
+                action_strings_per_plan.append(plan_action_strings)
+
+        plan_lengths = [len(plan) for plan in plans]
+        shortest_plan_idx = np.argmin(plan_lengths)
+
+        self.logger.info('Plan for task %s and robot %s found', task, robot)
+        self.logger.debug('Action sequence:')
+        self.logger.debug('-------------------------------')
+        for action_string in action_strings_per_plan[shortest_plan_idx]:
+            self.logger.debug(action_string)
+        self.logger.debug('-------------------------------')
+        return True, plans[shortest_plan_idx]
+
+    def process_action_str(self, action_line: str) -> Action:
+        action_data = action_line[action_line.find(':')+2:].split()
+        action_name = action_data[0]
+        action_params = action_data[1:]
+        action = ActionModelLibrary.get_action_model(action_name, action_params)
+        return action

--- a/task_planner/metric_ff_interface.py
+++ b/task_planner/metric_ff_interface.py
@@ -1,7 +1,7 @@
 from os.path import join
 import uuid
 import subprocess
-from typing import Tuple, List
+from typing import Tuple, Sequence
 import logging
 
 from ropod.structs.task import TaskRequest
@@ -11,7 +11,7 @@ from ropod.structs.area import Area
 from task_planner.planner_interface import TaskPlannerInterface
 from task_planner.knowledge_base_interface import Predicate
 from task_planner.action_models import ActionModelLibrary
-from task_planner.knowledge_models import PDDLPredicateLibrary, PDDLFluentLibrary
+from task_planner.knowledge_models import PDDLPredicateLibrary, PDDLNumericFluentLibrary
 
 
 class MetricFFInterface(TaskPlannerInterface):
@@ -66,7 +66,7 @@ class MetricFFInterface(TaskPlannerInterface):
 
     def generate_problem_file(self, predicate_assertions: list,
                               fluent_assertions: list,
-                              task_goals: List[Predicate]) -> str:
+                              task_goals: Sequence[Predicate]) -> str:
         obj_types = {}
         init_state_str = ''
 
@@ -80,7 +80,7 @@ class MetricFFInterface(TaskPlannerInterface):
             init_state_str += assertion_str
 
 
-        # for numeric fluents, we generate strings  of the form
+        # for numeric fluents, we generate strings of the form
         # (= (fluent_name param_1 param_2 ... param_n) fluent_value); otherwise,
         # we generate strings just like for predicate assertions
         for assertion in fluent_assertions:
@@ -92,9 +92,9 @@ class MetricFFInterface(TaskPlannerInterface):
                                                                  ' '.join(ordered_param_list),
                                                                  assertion.value)
             else:
-                ordered_param_list, obj_types = PDDLFluentLibrary.get_assertion_param_list(assertion.name,
-                                                                                           assertion.params,
-                                                                                           obj_types)
+                ordered_param_list, obj_types = PDDLNumericFluentLibrary.get_assertion_param_list(assertion.name,
+                                                                                                  assertion.params,
+                                                                                                  obj_types)
                 assertion_str = '        (= ({0} {1}) {2})\n'.format(assertion.name,
                                                                      ' '.join(ordered_param_list),
                                                                      assertion.value)

--- a/test/lama_test.py
+++ b/test/lama_test.py
@@ -79,6 +79,10 @@ class LamaPlannerTest(unittest.TestCase):
         # 4. UNDOCK
         assert len(plan) == 4
 
+        expected_action_sequence = ['GOTO', 'DOCK', 'GOTO', 'UNDOCK']
+        obtained_action_sequence = [action.type for action in plan]
+        assert expected_action_sequence == obtained_action_sequence
+
     def test_delivery_location_diff_floor(self):
         state_facts = [('empty_gripper', [('bot', 'frank')])]
         state_fluents = [('robot_at', [('bot', 'frank')], 'charging_station'),
@@ -130,7 +134,20 @@ class LamaPlannerTest(unittest.TestCase):
         # 9. EXIT_ELEVATOR
         # 10. GOTO delivery_location
         # 11. UNDOCK
+        # though RIDE_ELEVATOR can also be followed by WAIT_FOR_ELEVATOR
         assert len(plan) == 11
+
+        allowed_action_sequence1 = ['GOTO', 'DOCK', 'GOTO', 'REQUEST_ELEVATOR',
+                                    'WAIT_FOR_ELEVATOR', 'ENTER_ELEVATOR',
+                                    'WAIT_FOR_ELEVATOR', 'RIDE_ELEVATOR',
+                                    'EXIT_ELEVATOR', 'GOTO', 'UNDOCK']
+        allowed_action_sequence2 = ['GOTO', 'DOCK', 'GOTO', 'REQUEST_ELEVATOR',
+                                    'WAIT_FOR_ELEVATOR', 'ENTER_ELEVATOR',
+                                    'RIDE_ELEVATOR', 'WAIT_FOR_ELEVATOR',
+                                    'EXIT_ELEVATOR', 'GOTO', 'UNDOCK']
+        obtained_action_sequence = [action.type for action in plan]
+        assert (allowed_action_sequence1 == obtained_action_sequence) or\
+               (allowed_action_sequence2 == obtained_action_sequence)
 
     def test_robot_cart_diff_floors(self):
         state_facts = [('empty_gripper', [('bot', 'frank')])]
@@ -191,7 +208,38 @@ class LamaPlannerTest(unittest.TestCase):
         # 16. EXIT_ELEVATOR
         # 17. GOTO delivery_location
         # 18. UNDOCK
+        # though RIDE_ELEVATOR can also be followed by WAIT_FOR_ELEVATOR
         assert len(plan) == 18
+
+        allowed_action_sequence1 = ['GOTO', 'REQUEST_ELEVATOR', 'WAIT_FOR_ELEVATOR',
+                                    'ENTER_ELEVATOR', 'WAIT_FOR_ELEVATOR', 'RIDE_ELEVATOR',
+                                    'EXIT_ELEVATOR', 'GOTO', 'DOCK', 'GOTO',
+                                    'REQUEST_ELEVATOR', 'WAIT_FOR_ELEVATOR', 'ENTER_ELEVATOR',
+                                    'WAIT_FOR_ELEVATOR', 'RIDE_ELEVATOR', 'EXIT_ELEVATOR',
+                                    'GOTO', 'UNDOCK']
+        allowed_action_sequence2 = ['GOTO', 'REQUEST_ELEVATOR', 'WAIT_FOR_ELEVATOR',
+                                    'ENTER_ELEVATOR', 'RIDE_ELEVATOR', 'WAIT_FOR_ELEVATOR',
+                                    'EXIT_ELEVATOR', 'GOTO', 'DOCK', 'GOTO',
+                                    'REQUEST_ELEVATOR', 'WAIT_FOR_ELEVATOR', 'ENTER_ELEVATOR',
+                                    'WAIT_FOR_ELEVATOR', 'RIDE_ELEVATOR', 'EXIT_ELEVATOR',
+                                    'GOTO', 'UNDOCK']
+        allowed_action_sequence3 = ['GOTO', 'REQUEST_ELEVATOR', 'WAIT_FOR_ELEVATOR',
+                                    'ENTER_ELEVATOR', 'WAIT_FOR_ELEVATOR', 'RIDE_ELEVATOR',
+                                    'EXIT_ELEVATOR', 'GOTO', 'DOCK', 'GOTO',
+                                    'REQUEST_ELEVATOR', 'WAIT_FOR_ELEVATOR', 'ENTER_ELEVATOR',
+                                    'RIDE_ELEVATOR', 'WAIT_FOR_ELEVATOR', 'EXIT_ELEVATOR',
+                                    'GOTO', 'UNDOCK']
+        allowed_action_sequence4 = ['GOTO', 'REQUEST_ELEVATOR', 'WAIT_FOR_ELEVATOR',
+                                    'ENTER_ELEVATOR', 'RIDE_ELEVATOR', 'WAIT_FOR_ELEVATOR',
+                                    'EXIT_ELEVATOR', 'GOTO', 'DOCK', 'GOTO',
+                                    'REQUEST_ELEVATOR', 'WAIT_FOR_ELEVATOR', 'ENTER_ELEVATOR',
+                                    'RIDE_ELEVATOR', 'WAIT_FOR_ELEVATOR', 'EXIT_ELEVATOR',
+                                    'GOTO', 'UNDOCK']
+        obtained_action_sequence = [action.type for action in plan]
+        assert (allowed_action_sequence1 == obtained_action_sequence) or\
+               (allowed_action_sequence2 == obtained_action_sequence) or\
+               (allowed_action_sequence3 == obtained_action_sequence) or\
+               (allowed_action_sequence4 == obtained_action_sequence)
 
     @classmethod
     def _drop_test_db(self):

--- a/test/lama_test.py
+++ b/test/lama_test.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+
+import os
+import unittest
+import pymongo as pm
+import yaml
+
+from ropod.structs.task import TaskRequest
+from task_planner.lama_interface import LAMAInterface
+
+def get_planner_config(config_file_path):
+    planner_config_params = None
+    with open(config_file_path, 'r') as config_file:
+        planner_config_params = yaml.load(config_file)
+    return planner_config_params
+
+class LamaPlannerTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.test_kb_name = 'test_robot_store'
+        host, port = self._get_db_host_and_port()
+        self.client = pm.MongoClient(host=host, port=port)
+
+        planner_config_params = get_planner_config('../config/planner_config.yaml')
+        domain_file = planner_config_params['domain_file']
+        planner_cmd = planner_config_params['planner_cmd']
+        plan_file_path = planner_config_params['plan_file_path']
+        self.planner_interface = LAMAInterface(self.test_kb_name, domain_file,
+                                               planner_cmd, plan_file_path,
+                                               debug=True)
+
+    @classmethod
+    def tearDownClass(self):
+        self._drop_test_db()
+
+    def test_robot_cart_same_floor(self):
+        state_facts = [('empty_gripper', [('bot', 'frank')])]
+        state_fluents = [('robot_at', [('bot', 'frank')], 'charging_station'),
+                         ('load_at', [('load', 'mobidik')], 'pickup_location')]
+
+        floor_facts = [('elevator_at', [('elevator', 'toma_elevator'), ('loc', 'elevator0')]),
+                       ('elevator_at', [('elevator', 'toma_elevator'), ('loc', 'elevator1')]),
+                       ('elevator_at', [('elevator', 'toma_elevator'), ('loc', 'elevator2')])]
+        floor_fluents = [('robot_floor', [('bot', 'frank')], 'floor0'),
+                         ('load_floor', [('load', 'mobidik')], 'floor0'),
+                         ('elevator_floor', [('elevator', 'toma_elevator')], 'unknown'),
+                         ('destination_floor', [('elevator', 'toma_elevator')], 'unknown'),
+                         ('location_floor', [('loc', 'charging_station')], 'floor0'),
+                         ('location_floor', [('loc', 'pickup_location')], 'floor0'),
+                         ('location_floor', [('loc', 'delivery_location')], 'floor0'),
+                         ('location_floor', [('loc', 'elevator0')], 'floor0'),
+                         ('location_floor', [('loc', 'elevator2')], 'floor0')]
+
+        self.planner_interface.kb_interface.insert_facts(state_facts)
+        self.planner_interface.kb_interface.insert_facts(floor_facts)
+        self.planner_interface.kb_interface.insert_fluents(state_fluents)
+        self.planner_interface.kb_interface.insert_fluents(floor_fluents)
+
+        task_request = TaskRequest()
+        task_request.load_id = 'mobidik'
+        task_request.delivery_pose.id = 'delivery_location'
+
+        task_goals = [('load_at', [('load', task_request.load_id),
+                                   ('loc', task_request.delivery_pose.id)]),
+                      ('empty_gripper', [('bot', 'frank')])]
+        plan_found, plan = self.planner_interface.plan(task_request, 'frank', task_goals)
+
+        self.planner_interface.kb_interface.remove_facts(state_facts)
+        self.planner_interface.kb_interface.remove_facts(floor_facts)
+        self.planner_interface.kb_interface.remove_fluents(state_fluents)
+        self.planner_interface.kb_interface.remove_fluents(floor_fluents)
+
+        assert plan_found
+
+        # the expected plan is:
+        # 1. GOTO pickup_location
+        # 2. DOCK
+        # 3. GOTO delivery_location
+        # 4. UNDOCK
+        assert len(plan) == 4
+
+    def test_delivery_location_diff_floor(self):
+        state_facts = [('empty_gripper', [('bot', 'frank')])]
+        state_fluents = [('robot_at', [('bot', 'frank')], 'charging_station'),
+                         ('load_at', [('load', 'mobidik')], 'pickup_location')]
+
+        floor_facts = [('elevator_at', [('elevator', 'toma_elevator'), ('loc', 'elevator0')]),
+                       ('elevator_at', [('elevator', 'toma_elevator'), ('loc', 'elevator1')]),
+                       ('elevator_at', [('elevator', 'toma_elevator'), ('loc', 'elevator2')])]
+        floor_fluents = [('robot_floor', [('bot', 'frank')], 'floor0'),
+                         ('load_floor', [('load', 'mobidik')], 'floor0'),
+                         ('elevator_floor', [('elevator', 'toma_elevator')], 'unknown'),
+                         ('destination_floor', [('elevator', 'toma_elevator')], 'unknown'),
+                         ('location_floor', [('loc', 'charging_station')], 'floor0'),
+                         ('location_floor', [('loc', 'pickup_location')], 'floor0'),
+                         ('location_floor', [('loc', 'delivery_location')], 'floor2'),
+                         ('location_floor', [('loc', 'elevator0')], 'floor0'),
+                         ('location_floor', [('loc', 'elevator2')], 'floor2')]
+
+        self.planner_interface.kb_interface.insert_facts(state_facts)
+        self.planner_interface.kb_interface.insert_facts(floor_facts)
+        self.planner_interface.kb_interface.insert_fluents(state_fluents)
+        self.planner_interface.kb_interface.insert_fluents(floor_fluents)
+
+        task_request = TaskRequest()
+        task_request.load_id = 'mobidik'
+        task_request.delivery_pose.id = 'delivery_location'
+
+        task_goals = [('load_at', [('load', task_request.load_id),
+                                   ('loc', task_request.delivery_pose.id)]),
+                      ('empty_gripper', [('bot', 'frank')])]
+        plan_found, plan = self.planner_interface.plan(task_request, 'frank', task_goals)
+
+        self.planner_interface.kb_interface.remove_facts(state_facts)
+        self.planner_interface.kb_interface.remove_facts(floor_facts)
+        self.planner_interface.kb_interface.remove_fluents(state_fluents)
+        self.planner_interface.kb_interface.remove_fluents(floor_fluents)
+
+        assert plan_found
+
+        # the expected plan is:
+        # 1. GOTO pickup_location
+        # 2. DOCK
+        # 3. GOTO elevator0
+        # 4. REQUEST_ELEVATOR floor0 floor2
+        # 5. WAIT_FOR_ELEVATOR
+        # 6. ENTER_ELEVATOR
+        # 7. WAIT_FOR_ELEVATOR
+        # 8. RIDE_ELEVATOR
+        # 9. EXIT_ELEVATOR
+        # 10. GOTO delivery_location
+        # 11. UNDOCK
+        assert len(plan) == 11
+
+    def test_robot_cart_diff_floors(self):
+        state_facts = [('empty_gripper', [('bot', 'frank')])]
+        state_fluents = [('robot_at', [('bot', 'frank')], 'charging_station'),
+                         ('load_at', [('load', 'mobidik')], 'pickup_location')]
+
+        floor_facts = [('elevator_at', [('elevator', 'toma_elevator'), ('loc', 'elevator0')]),
+                       ('elevator_at', [('elevator', 'toma_elevator'), ('loc', 'elevator1')]),
+                       ('elevator_at', [('elevator', 'toma_elevator'), ('loc', 'elevator2')])]
+        floor_fluents = [('robot_floor', [('bot', 'frank')], 'floor0'),
+                         ('load_floor', [('load', 'mobidik')], 'floor2'),
+                         ('elevator_floor', [('elevator', 'toma_elevator')], 'unknown'),
+                         ('destination_floor', [('elevator', 'toma_elevator')], 'unknown'),
+                         ('location_floor', [('loc', 'charging_station')], 'floor0'),
+                         ('location_floor', [('loc', 'pickup_location')], 'floor2'),
+                         ('location_floor', [('loc', 'delivery_location')], 'floor1'),
+                         ('location_floor', [('loc', 'elevator0')], 'floor0'),
+                         ('location_floor', [('loc', 'elevator1')], 'floor1'),
+                         ('location_floor', [('loc', 'elevator2')], 'floor2')]
+
+        self.planner_interface.kb_interface.insert_facts(state_facts)
+        self.planner_interface.kb_interface.insert_facts(floor_facts)
+        self.planner_interface.kb_interface.insert_fluents(state_fluents)
+        self.planner_interface.kb_interface.insert_fluents(floor_fluents)
+
+        task_request = TaskRequest()
+        task_request.load_id = 'mobidik'
+        task_request.delivery_pose.id = 'delivery_location'
+
+        task_goals = [('load_at', [('load', task_request.load_id),
+                                   ('loc', task_request.delivery_pose.id)]),
+                      ('empty_gripper', [('bot', 'frank')])]
+        plan_found, plan = self.planner_interface.plan(task_request, 'frank', task_goals)
+
+        self.planner_interface.kb_interface.remove_facts(state_facts)
+        self.planner_interface.kb_interface.remove_facts(floor_facts)
+        self.planner_interface.kb_interface.remove_fluents(state_fluents)
+        self.planner_interface.kb_interface.remove_fluents(floor_fluents)
+
+        assert plan_found
+
+        # the expected plan is:
+        # 1. GOTO elevator0
+        # 2. REQUEST_ELEVATOR floor0 floor2
+        # 3. WAIT_FOR_ELEVATOR
+        # 4. ENTER_ELEVATOR
+        # 5. WAIT_FOR_ELEVATOR
+        # 6. RIDE_ELEVATOR
+        # 7. EXIT_ELEVATOR
+        # 8. GOTO pickup_location
+        # 9. DOCK
+        # 10. GOTO elevator2
+        # 11. REQUEST_ELEVATOR floor2 floor1
+        # 12. WAIT_FOR_ELEVATOR
+        # 13. ENTER_ELEVATOR
+        # 14. WAIT_FOR_ELEVATOR
+        # 15. RIDE_ELEVATOR
+        # 16. EXIT_ELEVATOR
+        # 17. GOTO delivery_location
+        # 18. UNDOCK
+        assert len(plan) == 18
+
+    @classmethod
+    def _drop_test_db(self):
+        if self.test_kb_name in self.client.list_database_names():
+            self.client.drop_database(self.test_kb_name)
+
+    @classmethod
+    def _get_db_host_and_port(self):
+        host = 'localhost'
+        port = 27017
+        if 'DB_HOST' in os.environ:
+            host = os.environ['DB_HOST']
+        if 'DB_PORT' in os.environ:
+            port = int(os.environ['DB_PORT'])
+        return (host, port)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary of changes

This PR modifies the domain `hospital_transportation.pddl` such that the floor is now represented as a variable rather than as a numeric fluent. This makes the domain compatible with the LAMA planner [1], which replaces the Metric-FF planner due to various issues we encountered with it while stress-testing on various problems.

Some of the knowledge models were also moved to a new `PDDLFluentLibrary` mapping class; the previous design in which I was treating many of these as predicates was inappropriate since it was allowing inconsistencies in the knowledge base (e.g. it was possible to assert that a robot is at two different locations at the same time). This particularly concerns the locations of the robots and loads.

[1] S. Richter and M. Westphal, "The LAMA Planner: Guiding Cost-Based Anytime Planning with Landmarks", Journal of Artificial Intelligence Research, vol. 39, no. 1, pp. 127-177, 2010. Available: https://arxiv.org/abs/1401.3839

## TODOs before merging

* [x] Add a LAMA planner interface
* [x] Add more sample problems for more extensive tests
* [x] Add unit tests
* [x] Update the documentation to reflect the changes