### PR TITLE
Add shell script to install the LAMA planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ plan_found, plan = planner.plan(task_request, robot_name, task_goals)
 
 ## Planner Setup
 
-For setting up the LAMA planner, the instructions at https://github.com/b-it-bots/lama_planner should suffice.
+For setting up the LAMA planner, execute the install script:
+```
+./install_LAMA_planner.sh
+```
 
 For Metric-FF, the executable can be downloaded from the home page of the planner: https://fai.cs.uni-saarland.de/hoffmann/metric-ff.html
 

--- a/install_LAMA_planner.sh
+++ b/install_LAMA_planner.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Exit immediately if any command exits with a nonzero exit value
+set -e
+
+# Fast-downward planner with the desired version
+PLANNER_NAME=fast-downward-19.06
+
+TARBALL="${PLANNER_NAME}.tar.gz"
+TARBALL_URL="http://www.fast-downward.org/Releases/19.06?action=AttachFile&do=get&target=${TARBALL}"
+
+# Install paths
+INSTALL_DIR_ROOT="/opt/ropod/task-planner/bin"
+INSTALL_DIR_NAME="fast-downward"
+INSTALL_DIR=$INSTALL_DIR_ROOT/$INSTALL_DIR_NAME
+
+# Pre-install cleanup
+if [ -d $INSTALL_DIR ]; then
+  echo "Removing existing planner from ${INSTALL_DIR} ..."
+  rm -rf $INSTALL_DIR
+fi
+
+# Fresh Installation
+echo "Installing LAMA planner"
+cd $INSTALL_DIR_ROOT
+wget $TARBALL_URL -O $TARBALL
+tar sxvf $TARBALL
+mv $PLANNER_NAME $INSTALL_DIR_NAME
+rm -f $TARBALL
+python $INSTALL_DIR_NAME/build.py


### PR DESCRIPTION
Introduced a new shell script to download and install the LAMA planner to the `/opt/ropod/task-planner/bin` directory for local builds. The script removes any previous versions of the LAMA planner and installs a fresh copy.